### PR TITLE
sysctl-related build failures with glibc 2.31+ #11

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -25,6 +25,11 @@ AC_INIT([BSD], [1.9.0])
 #-----------
 AC_CHECK_HEADERS(sys/vfs.h)
 
+#-----------
+# Check to see if we have sysctl.h
+#-----------
+AC_CHECK_HEADERS(sys/sysctl.h)
+
 
 #-----------
 # Check to see if we have functions setproctitle, statfs, statvfs

--- a/generic/sysctl.c
+++ b/generic/sysctl.c
@@ -19,7 +19,7 @@
 
 #include <sys/param.h>
 #include <sys/resource.h>
-#ifdef CPUSTATES
+#ifdef HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
 #endif
 #include <errno.h>

--- a/generic/sysctl.c
+++ b/generic/sysctl.c
@@ -19,7 +19,9 @@
 
 #include <sys/param.h>
 #include <sys/resource.h>
+#ifdef CPUSTATES
 #include <sys/sysctl.h>
+#endif
 #include <errno.h>
 #include <assert.h>
 


### PR DESCRIPTION
Test for sys/sysctl.h in configure.in